### PR TITLE
CI: specify stretch in CircleCI build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     parallelism: 1
     docker:
-      - image: circleci/ruby:2.6.3-node-browsers
+      - image: circleci/ruby:2.6.3-stretch-node-browsers
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3


### PR DESCRIPTION
CircleCI recommends pinning the OS version for build consistency.
Stretch is the latest and Jessie is end of life.

https://circleci.com/docs/2.0/circleci-images/#best-practices