### PR TITLE
Specs: set up test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 .c9
 notes.txt
 spec/examples.txt
+/coverage/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,16 +11,19 @@ Rails: { Enabled: true }
 
 Style/MethodCallWithArgsParentheses:
   IgnoredMethods:
+    - describe
     - exec
     - exit
     - gem
     - include
     - load
     - puts
+    - rails_require
     - require
     - require_relative
     - ruby
     - source
+    - to
     - warn
   IncludedMacros:
     - system!

--- a/Gemfile
+++ b/Gemfile
@@ -41,5 +41,6 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
+  gem "simplecov", require: false
   gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
+    docile (1.3.1)
     equatable (0.6.0)
     erubi (1.8.0)
     execjs (2.7.0)
@@ -101,6 +102,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
+    json (2.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -229,6 +231,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (4.1.0)
       activesupport (>= 4.2.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -306,6 +313,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   shoulda-matchers
+  simplecov
   spring
   spring-watcher-listen
   turbolinks

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "action_cable"
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "action_cable"
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
+require "action_controller"
+
 class ApplicationController < ActionController::Base
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
+require "active_job"
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "action_mailer"
+
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_record"
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/spec/channels/application_cable/channel_spec.rb
+++ b/spec/channels/application_cable/channel_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+rails_require "app/channels/application_cable/channel"
+
+RSpec.describe ApplicationCable::Channel do
+  it "exists" do
+    expect(described_class).to be_present
+  end
+end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+rails_require "app/channels/application_cable/connection"
+
+RSpec.describe ApplicationCable::Connection do
+  it "exists" do
+    expect(described_class).to be_present
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+rails_require "app/controllers/application_controller"
+
+RSpec.describe ApplicationController do
+  it "exists" do
+    expect(described_class).to be_present
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+rails_require "app/helpers/application_helper"
+
+RSpec.describe ApplicationHelper do
+  it "exists" do
+    expect(described_class).to be_present
+  end
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+rails_require "app/jobs/application_job"
+
+RSpec.describe ApplicationJob do
+  it "exists" do
+    expect(described_class).to be_present
+  end
+end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+rails_require "app/mailers/application_mailer"
+
+RSpec.describe ApplicationMailer do
+  it "exists" do
+    expect(described_class).to be_present
+  end
+end

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+rails_require "app/models/application_record"
+
+RSpec.describe ApplicationRecord do
+  it "exists" do
+    expect(described_class).to be_present
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+require "simplecov"
+SimpleCov.start("rails")
+SimpleCov.minimum_coverage(100)
+
+def rails_require(path)
+  require_relative "../#{path}"
+end
+
 RSpec.configure do |config|
   config.expect_with(:rspec) do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`


### PR DESCRIPTION
Built out simple files to test existing empty classes. I'm trying out a
test require strategy where we manually require files under test rather
than requiring `rails_helper` to pull in all of the Rails dependencies.
This should lead to faster individual test runs, though we'll see how
egregious it ends up being to add this to files.