### PR TITLE
fix warnings from puma

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,3 +58,4 @@ Style/Documentation: { Enabled: false }
 Style/DocumentationMethod: { Enabled: false }
 Style/InlineComment: { Enabled: false }
 Style/MissingElse: { Enabled: false }
+Style/StringHashKeys: { Enabled: false }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control": "public, max-age=#{Integer(2.days)}"
+      "Cache-Control" => "public, max-age=#{Integer(2.days)}"
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control": "public, max-age=#{Integer(1.hour)}"
+    "Cache-Control" => "public, max-age=#{Integer(1.hour)}"
   }
 
   # Show full error reports and disable caching.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,6 +3,7 @@
 require "capybara/rails"
 require "capybara-screenshot/rspec"
 
+Capybara.server = :puma, { Silent: true }
 Capybara.drivers[:chrome] = Capybara.drivers[:selenium_chrome]
 Capybara.drivers[:firefox] = Capybara.drivers[:selenium]
 Capybara.save_path = ENV.fetch("CIRCLE_ARTIFACTS", Capybara.save_path)


### PR DESCRIPTION
Puma had a noisy warning about header keys being invalid, and there was
another warning about Puma booting up when capybara first starts.

I also disabled the `Style/StringHashKeys` rule, as it wants to change
this. It's not a very safe rule for auto-correct, so probably best to
leave off.