### PR TITLE
Disable remote forms by default

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -1,0 +1,10 @@
+## default forms to being remote
+
+We disabled remote forms when using `form_with` because things like flash
+messages don't show up when we re-render. Maybe we can come up with a way of
+adding a `layout/application.js.haml` to insert flashes into the page
+dynamically. Search for the configuration:
+
+```rb
+Rails.application.config.action_view.form_with_generates_remote_forms = false
+```

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,7 @@ module YourAppNameHere
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    Rails.application.config.action_view.form_with_generates_remote_forms = false
   end
 end


### PR DESCRIPTION
When using `form_with` in Rails, it defaults to ajax submitting them.
The problem here is that the behavior is inconsistent when JS is enabled
or disabled. Flash messages don't display when JS is enabled, and there
needs to be a `.js.haml` template to update the page via JS if there is
any other update to be done. This causes some duplication between the
formats, so it would be nice to come up with a transparent way to make
both work with minimal duplication.