### PR TITLE
CircleCI: disable browser builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,8 @@ jobs:
           name: Run rspec in parallel
           command: |
             COVERAGE=true bundle exec rspec
-            DRIVER=firefox bundle exec rspec spec/system
-            DRIVER=chrome bundle exec rspec spec/system
+            # DRIVER=firefox bundle exec rspec spec/system
+            # DRIVER=chrome bundle exec rspec spec/system
             # bundle exec rspec --profile 10 \
             #                   --format RspecJunitFormatter \
             #                   --out test_results/rspec.xml \


### PR DESCRIPTION
This will prevent non-JS tests from running against browsers. Right now
submitting forms results in different error flows depending on whether
we're running against `Rack::Test` or `Selenium`. I'd like to sync this
up at some point, but for now only tests with `js: true` will run
against a real browser.