### PR TITLE
don't validate password_digest

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,4 @@ class User < ApplicationRecord
   has_secure_password
 
   validates :email, presence: true, format: URI::MailTo::EMAIL_REGEXP
-  validates :password_digest, presence: true
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to validate_presence_of(:password_digest) }
   it { is_expected.to have_secure_password }
 
   it "allows good emails" do


### PR DESCRIPTION
This results in an unactionable `password_digest` message being
displayed to the user. `has_secure_password` already validates presence
of `password` and validates confirmation of `password_confirmation`.