### PR TITLE
Rubocop: remove unneeded settings from .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,7 @@ AllCops:
   DefaultFormatter: fuubar
   DisplayCopNames: true
   EnabledByDefault: true
-  TargetRailsVersion: 5.2
-  TargetRubyVersion: 2.6
   Exclude: [node_modules/**/*, vendor/**/*]
-Rails: { Enabled: true }
 
 ################################################################################
 #


### PR DESCRIPTION
`TargetRubyVersion` and `TargetRailsVersion` are automatically detected
by rubocop. `TargetRubyVersion` is [grabbed from `.ruby-version`][1] and
`TargetRailsVersion` [comes from `Gemfile.lock`][2]. Also, the `Rails`
setting is no longer necessary, as that is triggered by the fact that we
have a `require` line above for `rubocop-rails`.

[1]: https://github.com/rubocop-hq/rubocop/blob/HEAD@%7B2019-09-18T17:12:48Z%7D/manual/configuration.md#setting-the-target-ruby-version
[2]: https://github.com/rubocop-hq/rubocop-rails/blob/20586297d465867e7e19176a98e606516c6b81d3/config/default.yml#L6-L12