### PR TITLE
RSpec: add a bunch of testing helpers

### DIFF
--- a/spec/support/capybara/rack_test.rb
+++ b/spec/support/capybara/rack_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Capybara
+  module RackTest
+    class Driver < Capybara::Driver::Base
+      def accept_modal(_type, text: nil, **_options)
+        escaped_text = Capybara::Selector::CSS.escape(text)
+        unless browser.find(:css, "[data-confirm='#{escaped_text}']").any?
+          raise Capybara::ElementNotFound,
+                "Unable to find modal with text \"#{text}\""
+        end
+
+        yield
+      end
+    end
+  end
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+def have_error(expected_message)
+  Matchers::HaveError.new(expected_message)
+end
+
+def have_flash(expected_type, expected_message)
+  Matchers::HaveFlash.new(expected_type, expected_message)
+end
+
+def change_record(record, attribute)
+  Matchers::ChangeRecord.new(record, attribute)
+end
+
+def delete_record(record)
+  Matchers::DeleteRecord.new(record)
+end
+
+RSpec::Matchers.define_negated_matcher(:not_change, :change)
+RSpec::Matchers.define_negated_matcher(:not_change_record, :change_record)
+RSpec::Matchers.define_negated_matcher(:not_delete_record, :delete_record)

--- a/spec/support/matchers/change_record.rb
+++ b/spec/support/matchers/change_record.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Matchers
+  class ChangeRecord
+    include RSpec::Matchers::Composable
+
+    attr_reader :record,
+                :attribute,
+                :original_value,
+                :new_value,
+                :expected_new_value,
+                :expected_original_value
+
+    def initialize(record, attribute)
+      @record = record
+      @attribute = attribute
+      @expected_original_value = :__not_set__
+      @expected_new_value = :__not_set__
+    end
+
+    def supports_block_expectations?
+      true
+    end
+
+    def matches?(event_proc)
+      perform_change(event_proc)
+
+      original_value_matches? && changed? && new_value_matches?
+    end
+
+    def from(expected_original_value)
+      @expected_original_value = expected_original_value
+      self
+    end
+
+    def does_not_match?(event_proc)
+      if new_value_expected?
+        raise NotImplementedError,
+              "`expect { }.not_to change_record().to()` is not supported"
+      end
+
+      perform_change(event_proc)
+
+      original_value_matches? && !changed?
+    end
+
+    def to(expected_new_value)
+      @expected_new_value = expected_new_value
+      self
+    end
+
+    def failure_message
+      if !original_value_matches?
+        original_value_does_not_match_message
+      elsif !changed?
+        value_did_not_change_message
+      else # new value doesn't match
+        new_value_does_not_match_message
+      end
+    end
+
+    def failure_message_when_negated
+      if !original_value_matches?
+        original_value_does_not_match_message
+      else # record changed
+        value_changed_message
+      end
+    end
+
+    private
+
+    def perform_change(event_proc)
+      @original_value = record[attribute]
+
+      event_proc.call
+
+      @new_value = record.reload[attribute]
+    end
+
+    def original_value_does_not_match_message
+      <<~MESSAGE.squish
+        expected original value to be #{expected_original_value} but was
+        #{original_value}
+      MESSAGE
+    end
+
+    def value_did_not_change_message
+      if new_value_expected?
+        <<~MESSAGE.squish
+          expected value to change from #{original_value} to
+          #{expected_new_value} but did not change
+        MESSAGE
+      else
+        <<~MESSAGE.squish
+          expected value to change from #{original_value} but did not change
+        MESSAGE
+      end
+    end
+
+    def new_value_does_not_match_message
+      <<~MESSAGE.squish
+        expected value to change to #{expected_new_value} but changed to
+        #{new_value}
+      MESSAGE
+    end
+
+    def value_changed_message
+      <<~MESSAGE.squish
+        expected value not to change from #{original_value} but changed to
+        #{new_value}
+      MESSAGE
+    end
+
+    def original_value_matches?
+      !original_value_expected? || original_value == expected_original_value
+    end
+
+    def original_value_expected?
+      expected_original_value != :__not_set__
+    end
+
+    def changed?
+      new_value != original_value
+    end
+
+    def new_value_matches?
+      !new_value_expected? || new_value == expected_new_value
+    end
+
+    def new_value_expected?
+      expected_new_value != :__not_set__
+    end
+  end
+end

--- a/spec/support/matchers/delete_record.rb
+++ b/spec/support/matchers/delete_record.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Matchers
+  class DeleteRecord
+    include RSpec::Matchers::Composable
+
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+    end
+
+    def supports_block_expectations?
+      true
+    end
+
+    def matches?(event_proc)
+      perform_change(event_proc)
+
+      exists_before? && !exists_after?
+    end
+
+    def does_not_match?(event_proc)
+      perform_change(event_proc)
+
+      exists_before? && exists_after?
+    end
+
+    def failure_message
+      if !exists_before?
+        did_not_exist_before_message
+      else # was not deleted
+        existed_after_message
+      end
+    end
+
+    def failure_message_when_negated
+      if !exists_before?
+        did_not_exist_before_message
+      else # was deleted
+        did_not_exist_after_message
+      end
+    end
+
+    private
+
+    def perform_change(event_proc)
+      @exists_before = record.class.exists?(record.id)
+
+      event_proc.call
+
+      @exists_after = record.class.exists?(record.id)
+    end
+
+    def did_not_exist_before_message
+      <<~MESSAGE.squish
+        expected #{record.class.name} with id #{record.id} to originally exist,
+        but did not
+      MESSAGE
+    end
+
+    def existed_after_message
+      <<~MESSAGE.squish
+        expected #{record.class.name} with id #{record.id} to be deleted,
+        but was not deleted
+      MESSAGE
+    end
+
+    def did_not_exist_after_message
+      <<~MESSAGE.squish
+        expected #{record.class.name} with id #{record.id} not to be deleted,
+        but was deleted
+      MESSAGE
+    end
+
+    def exists_before?
+      @exists_before
+    end
+
+    def exists_after?
+      @exists_after
+    end
+  end
+end

--- a/spec/support/matchers/have_error.rb
+++ b/spec/support/matchers/have_error.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Matchers
+  class HaveError
+    attr_reader :actual, :expected_message
+
+    ERROR_SELECTOR = ".error_explanation li"
+
+    def initialize(expected_message)
+      @expected_message = expected_message
+    end
+
+    def matches?(actual)
+      @actual = actual
+
+      actual.has_selector?(ERROR_SELECTOR, text: expected_message)
+    end
+
+    def failure_message
+      <<~MESSAGE.squish
+        expected to find error with text #{expected_message} but found
+        #{actual.all(ERROR_SELECTOR).map(&:text)}
+      MESSAGE
+    end
+  end
+end

--- a/spec/support/matchers/have_flash.rb
+++ b/spec/support/matchers/have_flash.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Matchers
+  class HaveFlash
+    attr_reader :expected_type, :expected_message, :actual
+
+    def initialize(expected_type, expected_message)
+      @expected_type = expected_type
+      @expected_message = expected_message
+    end
+
+    def matches?(actual)
+      @actual = actual
+
+      actual.has_selector?(expected_selector, text: expected_message)
+    end
+
+    def failure_message
+      <<~MESSAGE.squish
+        expected to find #{expected_type} flash with text '#{expected_message}'
+        but found #{actual.all("[class^='flash-']").map(&:text)}
+      MESSAGE
+    end
+
+    private
+
+    def expected_selector
+      ".flash-#{expected_type}"
+    end
+  end
+end

--- a/spec/support/mocks.rb
+++ b/spec/support/mocks.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+FAKE_ID = "__fake_id__"
+
+def record_double(klass, method_overrides)
+  fake_record = klass.new
+  method_overrides.reverse_merge!(id: FAKE_ID)
+
+  mock_methods(fake_record, method_overrides)
+
+  RSpec::Mocks
+    .expect_message(klass, :find, expected_from: expected_from)
+    .with(FAKE_ID)
+    .at_least(:once)
+    .and_return(fake_record)
+
+  fake_record
+end
+
+def mock_methods(fake_record, method_overrides)
+  method_overrides.each do |method_name, return_value|
+    RSpec::Mocks
+      .expect_message(fake_record, method_name, expected_from: expected_from)
+      .at_least(:once)
+      .and_return(return_value)
+  end
+end
+
+def expected_from
+  caller.find { |line| !line.include?(__FILE__) }
+end


### PR DESCRIPTION
Several matchers and some additional stuff for various purposes.

- `RackTest` doesn't implement the `accept_modal` method of other
  drivers, so this adds it.
- `ChangeRecord` and `DeleteRecord` matchers implement common
  expectations around `ActiveRecord`.
- `have_error` and `have_flash` encapsulate some feature expectations.
- `record_double` abstracts away a common testing use case where we want
  to stub out some method on a record that is going to be found in the
  controller like so:

  ```rb
  user = User.create!(user_params)
  expect(user).to receive(:destroy).and_return(false)
  expect(User).to receive(:find).with(user.id).and_return(user)

  session[:user_id] = user.id
  ```

Most of these are "just enough" to work for the time being, but will
probably need to be refined as new use cases pop up.