### PR TITLE
default to authenticate user everywhere

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -3,7 +3,7 @@
 require_relative "application_controller"
 
 class AccountsController < ApplicationController
-  before_action(:authenticate_user, only: [:show, :update, :destroy])
+  skip_before_action(:authenticate_user, only: [:new, :create])
 
   def new
     render(locals: { user: User.new })

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@
 require "action_controller"
 
 class ApplicationController < ActionController::Base
+  before_action(:authenticate_user)
+
   private
 
   def current_user

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class WelcomeController < ApplicationController
+  skip_before_action(:authenticate_user)
 end


### PR DESCRIPTION
For security, we're better defaulting to requiring the user to be logged
in and selectively disabling it where appropriate.