### PR TITLE
introduce CallableJob

### DIFF
--- a/app/jobs/callable_job.rb
+++ b/app/jobs/callable_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "./application_job"
+
+class CallableJob < ApplicationJob
+  def perform(callable_name, *args)
+    callable_name.constantize.call(*args)
+  end
+end

--- a/spec/jobs/callable_job_spec.rb
+++ b/spec/jobs/callable_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+rails_require "app/jobs/callable_job"
+
+RSpec.describe CallableJob do
+  describe "#perform" do
+    it "constantizes and calls the given job class with 0 args" do
+      counts = {}
+      stub_const("MyTestCallable", -> { counts[:yep] = "five" })
+
+      described_class.new.perform("MyTestCallable")
+
+      expect(counts).to eq(yep: "five")
+    end
+
+    it "constantizes and calls the given job class with several args" do
+      counts = {}
+      stub_const("MyTestCallable", ->(key, value) { counts[key] = value })
+
+      described_class.new.perform("MyTestCallable", :foo, 5)
+
+      expect(counts).to eq(foo: 5)
+    end
+
+    it "constantizes and calls the given job class with hash args" do
+      counts = {}
+      stub_const("MyTestCallable", ->(key:, value:) { counts[key] = value })
+
+      described_class.new.perform("MyTestCallable", key: :foo, value: 5)
+
+      expect(counts).to eq(foo: 5)
+    end
+
+    it "raises an error when constant does not exist" do
+      expect { described_class.new.perform("NotACallable") }
+        .to raise_error(NameError)
+    end
+  end
+end


### PR DESCRIPTION
`CallableJob` is a generic job that allows us to easily background any
class or constant that implements a `call` method without needing to
introduce a new type of job. This also makes zero downtime deploys
easier, since we don't need an extra step to introduce the new job
before adding any code that references it, though we still need to make
sure the callable is in production before adding any code that will
depend on it via `CallableJob`. This is less likely to be a problem,
however, since often times the logic that we want to background is
already in production and is slowing down the request lifecycle. We can
quickly change the logic to background it like so:

```diff
- MyThing.call(args)
+ CallableJob.perform_later("MyThing", args)
```