### PR TITLE
Sync standard out

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,6 +2,8 @@
 
 # This file is used by Rack-based servers to start the application.
 
+$stdout.sync = true
+
 require_relative "config/environment"
 
 run Rails.application


### PR DESCRIPTION
By default Ruby buffers to $stdout, which means output won't appear until a threshold has been reached.
This can make logging confusing because you won't see actions that have been performed immediately in the logs.
Setting sync to true tells Ruby to immediately flush all output.