### PR TITLE
More rubocop updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Metrics/BlockLength:
     - describe
   Exclude:
     - Guardfile
+    - db/schema.rb
 Metrics/LineLength:
   Exclude:
     - 'config/**/*'
@@ -32,13 +33,16 @@ RSpec/MessageExpectation: { EnforcedStyle: expect }
 Style/MethodCallWithArgsParentheses:
   IgnoredMethods:
     - attr_reader
+    - belongs_to
     - context
     - default
+    - delegate
     - describe
     - exec
     - exit
     - fit
     - gem
+    - has_many
     - helper_method
     - include
     - it
@@ -53,6 +57,7 @@ Style/MethodCallWithArgsParentheses:
     - require_relative
     - ruby
     - source
+    - store_accessor
     - to
     - validates
     - warn
@@ -67,11 +72,13 @@ Style/MethodCallWithArgsParentheses:
     - Guardfile
     - Gemfile
 Style/MixinUsage: { Exclude: ['bin/**/*'] }
+Style/NumericLiterals: { Exclude: [db/schema.rb] }
 Style/StringLiterals: { EnforcedStyle: double_quotes }
 Style/SymbolArray: { EnforcedStyle: brackets }
 Style/TrailingCommaInArguments: { EnforcedStyleForMultiline: comma }
 Style/TrailingCommaInArrayLiteral: { EnforcedStyleForMultiline: comma }
 Style/TrailingCommaInHashLiteral: { EnforcedStyleForMultiline: comma }
+Style/WordArray: { EnforcedStyle: brackets }
 
 ################################################################################
 #

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,15 +12,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_913_200_312) do
+ActiveRecord::Schema.define(version: 2019_09_13_200312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string("email", null: false)
-    t.string("password_digest", null: false)
-    t.datetime("created_at", precision: 6, null: false)
-    t.datetime("updated_at", precision: 6, null: false)
-    t.index(["email"], name: "index_users_on_email", unique: true)
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 end


### PR DESCRIPTION
- Probably better not to wrap `schema.rb` methods in parens since its
  format is pretty common.
- Also don't enforce the underscore format for `schema.rb` timestamp. It
  reads more clearly with arbitrary positioning.
- Don't allow word array shorthand syntax. This is for the sake of
  consistency. Rather than having a custom syntax for one particular
  type of array, all arrays should look the same, as well as all
  strings, for the most part.