### PR TITLE
Disable `belongs_to` default validation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,19 +8,20 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module YourAppNameHere
+module LetMeKnowWhen
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults(6.0)
 
     config.active_job.queue_adapter     = :sidekiq
-    config.active_job.queue_name_prefix = "yourappnamehere_#{Rails.env}"
+    config.active_job.queue_name_prefix = "letmeknowwhen_#{Rails.env}"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.active_record.belongs_to_required_by_default = false
     config.action_view.form_with_generates_remote_forms = false
 
     config.autoload_paths << Rails.root.join("app/models/nulls")


### PR DESCRIPTION
This check can cause N+1 queries when validating multiple records.
Instead we can validate the presence of a foreign key, rather than the
actual record. As long as there is a foreign key constraint in the
database it will end up being just as good without the performance
implications.