### PR TITLE
Rubocop: configure more rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,10 +30,14 @@ RSpec/MultipleExpectations:
   Exclude:
     - spec/system/**/*.rb
 RSpec/MessageExpectation: { EnforcedStyle: expect }
+Style/CommentedKeyword: { Enabled: false }
 Style/MethodCallWithArgsParentheses:
   IgnoredMethods:
+    - attr_accessor
     - attr_reader
+    - attr_writer
     - belongs_to
+    - cattr_accessor
     - context
     - default
     - delegate
@@ -74,6 +78,7 @@ Style/MethodCallWithArgsParentheses:
 Style/MixinUsage: { Exclude: ['bin/**/*'] }
 Style/NumericLiterals: { Exclude: [db/schema.rb] }
 Style/StringLiterals: { EnforcedStyle: double_quotes }
+Style/StringLiteralsInInterpolation: { EnforcedStyle: double_quotes }
 Style/SymbolArray: { EnforcedStyle: brackets }
 Style/TrailingCommaInArguments: { EnforcedStyleForMultiline: comma }
 Style/TrailingCommaInArrayLiteral: { EnforcedStyleForMultiline: comma }

--- a/app/views/accounts/new.html.haml
+++ b/app/views/accounts/new.html.haml
@@ -3,7 +3,7 @@
 = form_with(model: user, url: account_path) do |form|
   - if user.errors.any?
     .error_explanation
-      %h2 #{pluralize(user.errors.count, 'error')} problems with your signup:
+      %h2 #{pluralize(user.errors.count, "error")} problems with your signup:
       %ul
         - user.errors.full_messages.each do |message|
           %li= message

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -3,7 +3,7 @@
 = form_with(model: user, url: account_path) do |form|
   - if user.errors.any?
     .error_explanation
-      %h2 #{pluralize(user.errors.count, 'error')} problems with your signup:
+      %h2 #{pluralize(user.errors.count, "error")} problems with your signup:
       %ul
         - user.errors.full_messages.each do |message|
           %li= message


### PR DESCRIPTION
- Add a few more methods for `Style/MethodCallWithArgsParentheses`
- Disable `Style/CommentedKeyword`. I want to be able to add closing
  comments to the `end` of some blocks, such as `class << self`.
- Switch `Style/StringLiteralsInInterpolation` to double quotes. Seems
  like this should mirror `Style/StringLiterals`.