### PR TITLE
Allow geckodriver for Webmock

### DIFF
--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -2,4 +2,4 @@
 
 require "webmock/rspec"
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: [/geckodriver/])


### PR DESCRIPTION
The `webdrivers` gem fetches browser drivers for system tests. WebMock
blocks these requests by default, so this allows them through.