### PR TITLE
CI: remove bundler audit check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,6 @@ jobs:
           name: Bundle Install
           command: bundle check || bundle install
 
-      - run:
-          name: Bundler Audit
-          command: bundle exec bundle audit
-
       - save_cache:
           key: bundle-v1-{{ checksum "Gemfile.lock" }}
           paths:


### PR DESCRIPTION
This actually prevents merging security updates, since there might be
more than one security vulnerability at the same. When there are
multiple PRs to fix security issues, they individually fail because
`bundle audit` fails on the other dependency that is not being updated.
